### PR TITLE
fixing typo in android build args

### DIFF
--- a/tutorial-gulp/gulp-ci.md
+++ b/tutorial-gulp/gulp-ci.md
@@ -133,7 +133,7 @@ var gulp = require("gulp"),
 var winPlatforms = ["android", "windows", "wp8"],
 	osxPlatforms = ["ios"],
 	buildArgs = {
-		android: ["--release", "--device", "--gradleArg=no-daemon"],
+		android: ["--release", "--device", "--gradleArg=-no-daemon"],
 		ios: ["--release", "--device"],
 		windows: ["--release", "--device"],
 		wp8: ["--release", "--device"]


### PR DESCRIPTION
Missing '-' character before "no-daemon" causes command to fail.